### PR TITLE
feat: remove specific headers from request before sending to target

### DIFF
--- a/util.go
+++ b/util.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"net/url"
+	"strings"
+)
+
+func getKeysByPrefix(query url.Values, prefix string) (keys []string) {
+	for k, _ := range query {
+		if strings.HasPrefix(k, prefix) {
+			keys = append(keys, k)
+		}
+	}
+	return
+}


### PR DESCRIPTION
The code has been updated to remove specific headers from the request before sending it to the target. This is done by checking for query parameters with a specific prefix and removing the corresponding headers from the request. This change ensures that unwanted headers are not sent to the target server.